### PR TITLE
商品一覧表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all.order('created_at DESC')
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,6 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
@@ -155,11 +154,9 @@
         <% end %>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <% if @user = nil %>
+      <% if @items = nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -178,7 +175,6 @@
         <% end %>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,10 +127,11 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item|%>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" if item.image.attached? %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
@@ -141,10 +142,10 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.burden_id %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,11 +153,13 @@
           </div>
         </div>
         <% end %>
+        <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% if @user = nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -172,6 +175,7 @@
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品がある場合は表示されないようにしましょう %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create, :index]
 end


### PR DESCRIPTION
# What
投稿した商品の一覧表示

# Why
投稿した商品が表示することができているのか？
また、画像や、商品名なども表示できているのかを確認するため。

Gyazo url

- ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること
https://i.gyazo.com/67c4824658d3490374cade2ba55f8a76.gif

-画像が表示されており、画像がリンク切れなどになっていないこと（Herokuの仕様による画像のリンク切れは、要件未達に含まれない。デプロイのタスクにあるとおり、Heroku上では一定時間経過すると画像が消える。）
- 出品した商品の一覧表示ができていること
- 上から、出品された日時が新しい順に表示されること
- 「画像/価格/商品名」の3つの情報について表示できていること
- 売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていること
https://i.gyazo.com/8ffa82b753e344e5e41727885418b3ca.gif


